### PR TITLE
Maps no longer change name from travel #61214 [CR]

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9862,7 +9862,11 @@ std::string item::get_book_skill() const
 
 bool item::is_map() const
 {
-    return get_category_shallow().get_id() == item_category_maps;
+    if((get_category_shallow().get_id() == item_category_maps) || (get_action() == "reveal_map")) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool item::seal()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes Maps no longer change name from travel
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Issue #61214 describes a bug in which found maps and trail guides will reveal map elements for the closest city to the player at the time of opening, rather then the location the map was found in.  This pull request is an attempt to fix the bug by implementing the fix suggested by ZhilkinSerg https://github.com/CleverRaven/Cataclysm-DDA/issues/61214#issuecomment-1257054422.  Bug was recreated in a virtual machine running Ubuntu 20.04 following Steps to Reproduce and instructions from https://github.com/CleverRaven/Cataclysm-DDA/issues/61214#issuecomment-1256946108
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The is_map function now returns true if either the item is in the Maps category, OR if the item has a "reveal_map" use action id, rather then purely the former.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Considered using the action name rather then id, but there are possibly cases that can circumvent these checks without being maps.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game compiled and testing with new build did not seem to recreate the bug.  This is admittedly more complex then the bug testing I usually do, so further testing is welcome. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
My first commit, please be gentle : )
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
